### PR TITLE
exec: Put provider in a subprocess (redesign)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,28 +879,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
 name = "futures-channel"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
 dependencies = [
  "futures-core",
- "futures-sink",
 ]
 
 [[package]]
@@ -908,34 +892,6 @@ name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "futures-sink"
@@ -955,16 +911,10 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
- "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
  "pin-utils",
- "slab",
 ]
 
 [[package]]
@@ -1443,10 +1393,10 @@ dependencies = [
  "axum",
  "base64 0.22.1",
  "base64ct",
+ "cfg-if",
  "chrono",
  "clap",
  "daemonize",
- "futures",
  "futures-core",
  "headers",
  "hyper 1.5.0",
@@ -1463,6 +1413,7 @@ dependencies = [
  "prost-types",
  "rand",
  "reqwest",
+ "rustix",
  "secrecy",
  "serde",
  "serde_json",
@@ -2108,9 +2059,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "aa260229e6538e52293eeb577aabd09945a09d6d9cc0fc550ed7529056c2e32a"
 dependencies = [
  "bitflags",
  "errno",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,10 @@ aws-sdk-ssooidc = "1.48.0"
 axum = { version = "0.7.4", features = ["tracing", "macros", "query"] }
 base64 = "0.22.1"
 base64ct = { version = "1.6.0", features = ["alloc", "std"] }
+cfg-if = "1.0.0"
 chrono = { version = "0.4.34", features = ["serde"] }
 clap = { version = "4.5.1", features = ["cargo", "derive", "env"] }
 daemonize = "0.5.0"
-futures = "0.3.31"
 futures-core = "0.3.31"
 headers = "0.4.0"
 hyper = { version = "1.1.0", features = ["http1", "server"] }
@@ -55,3 +55,6 @@ tracing-appender = "0.2.3"
 tracing-subscriber = { version = "0.3.18", features = ["fmt", "env-filter", "local-time", "json", "time"] }
 url = { version = "2.5.0", features = ["serde"] }
 zeroize = { version = "1.7.0", features = ["std", "aarch64", "zeroize_derive", "serde", "derive"] }
+
+[target.'cfg(any(target_os = "freebsd", target_os = "dragonfly"))'.dependencies]
+rustix = { version = "0.38.38", default-features = false, features = ["std", "process"] }

--- a/build.rs
+++ b/build.rs
@@ -2,6 +2,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .message_attribute("mairu.Credentials", "#[derive(zeroize::ZeroizeOnDrop)]")
         .field_attribute("mairu.Credentials.expiration", "#[zeroize(skip)]")
+        .message_attribute("mairu.ExecEnvVar", "#[derive(zeroize::ZeroizeOnDrop)]")
         .compile_protos(&["proto/mairu.proto"], &["proto"])?;
     Ok(())
 }

--- a/proto/mairu.proto
+++ b/proto/mairu.proto
@@ -121,3 +121,17 @@ message ExecEnvironment {
   repeated string remove_vars = 2;
 }
 // NOTE: ExecEnvironmentAction (helper enum) is implemented directly on proto.rs
+
+message ExecIpcInformExecutorRequest {
+  uint32 version = 1;
+  message Ready {
+    ExecEnvironment environment = 1;
+  }
+  message Failure {
+    string error_message = 1;
+  }
+  oneof result {
+    Ready ready = 2;
+    Failure failure = 3;
+  }
+}

--- a/proto/mairu.proto
+++ b/proto/mairu.proto
@@ -109,3 +109,15 @@ message CompleteAwsSsoDeviceRequest {
 }
 message CompleteAwsSsoDeviceResponse {
 }
+
+//----- The following is used for mairu-exec subprocess IPC
+
+message ExecEnvVar {
+  string name = 1;
+  string value = 2;
+}
+message ExecEnvironment {
+  repeated ExecEnvVar set_vars = 1;
+  repeated string remove_vars = 2;
+}
+// NOTE: ExecEnvironmentAction (helper enum) is implemented directly on proto.rs

--- a/src/cmd/exec.rs
+++ b/src/cmd/exec.rs
@@ -70,8 +70,6 @@ async fn run_inner(mut args: ExecArgs) -> Result<(), anyhow::Error> {
         auto_refresh::start(agent.clone(), args.clone(), initial_expiry); // keep running
     let _provider_shutdown_tx = start_provider(&mut agent, &args).await?; // keep provider running
 
-    // TODO: signal handling
-    // TODO: early credential cache refresh to workaround SDK timeouts
     execute(&args).await
 }
 #[tracing::instrument(skip_all)]

--- a/src/cmd/exec.rs
+++ b/src/cmd/exec.rs
@@ -29,20 +29,123 @@ pub struct ExecArgs {
     #[arg(long, env = "MAIRU_SHOW_AUTO_ROLE", default_value_t = false)]
     show_auto: bool,
 
-    #[arg(long)]
-    forward_signals: Vec<String>,
-
     #[arg(trailing_var_arg = true, allow_hyphen_values = true)]
     command: Vec<std::ffi::OsString>,
 }
 
+#[cfg(unix)]
 pub fn run(args: &ExecArgs) -> Result<(), anyhow::Error> {
     crate::config::trust_dir_mkpath()?;
-    run_inner(args.clone()) // XXX: &mut
+
+    // mairu-exec spawns a credential provider in a child process; we call it 'sidecar'.
+    // The specified command will be execvp(2)'d in a parent process; we call it 'executor'.
+    // This strategy lets Mairu transparent from other processes, in terms of handling signals and
+    // returning exit status; including signals.
+    //
+    // The executor first waits for an information from the sidecar. The sidecar informs the
+    // executor with necessary informations such as environment variables when it become ready. The
+    // executor then applies the variables and execvp(2)s the specified command line.
+    //
+    // The sidecar monitors the parent process (formerly an executor) while keep provider running,
+    // and terminates when the parent is gone.
+
+    let (ipc_i, ipc_o) = nix::unistd::pipe2(nix::fcntl::OFlag::O_CLOEXEC)?;
+    let pid = nix::unistd::Pid::this();
+    match unsafe { nix::unistd::fork() }? {
+        nix::unistd::ForkResult::Parent { child, .. } => {
+            drop(ipc_o);
+            executor::run(child, ipc_i, args.clone())
+        }
+        nix::unistd::ForkResult::Child => {
+            drop(ipc_i);
+            start_ignoring_signals();
+            run_sidecar(pid, ipc_o, args.clone())
+        }
+    }
 }
 
 #[tokio::main]
-async fn run_inner(mut args: ExecArgs) -> Result<(), anyhow::Error> {
+async fn run_sidecar(
+    parent: nix::unistd::Pid,
+    ipc: std::os::fd::OwnedFd,
+    args: ExecArgs,
+) -> Result<(), anyhow::Error> {
+    let main = do_sidecar(ipc, args);
+    let _result = tokio::spawn(main);
+    crate::ppid::wait_for_parent_process_die(parent).await?;
+    tracing::debug!("sidecar exiting");
+    Ok(())
+}
+
+struct SidecarHandler {
+    #[allow(dead_code)] // TODO: use SidecarHandler.auto_refresh_shutdown_tx
+    auto_refresh_shutdown_tx: Option<tokio::sync::oneshot::Sender<()>>,
+    provider: provider::ProviderHandle,
+}
+
+impl SidecarHandler {
+    fn info(&self) -> crate::proto::exec_ipc_inform_executor_request::Ready {
+        crate::proto::exec_ipc_inform_executor_request::Ready {
+            environment: Some(self.provider.environment.clone()),
+        }
+    }
+}
+
+async fn do_sidecar(
+    ipc: std::os::fd::OwnedFd,
+    args: ExecArgs,
+) -> Result<SidecarHandler, anyhow::Error> {
+    match do_sidecar_inner(args).await {
+        Ok(handler) => {
+            if let Err(e) = inform_executor(
+                ipc,
+                crate::proto::ExecIpcInformExecutorRequest::ready(handler.info()),
+            )
+            .await
+            {
+                tracing::warn!(err = ?e, "Error informing the executor")
+            };
+            Ok(handler)
+        }
+        Err(e) => {
+            if let Err(e) = inform_executor(
+                ipc,
+                crate::proto::ExecIpcInformExecutorRequest::failure(
+                    crate::proto::exec_ipc_inform_executor_request::Failure {
+                        error_message: e.to_string(),
+                    },
+                ),
+            )
+            .await
+            {
+                tracing::warn!(err = ?e, "Error informing the executor an error")
+            };
+            Err(e)
+        }
+    }
+}
+
+async fn inform_executor(
+    ipc_fd: std::os::fd::OwnedFd,
+    message: crate::proto::ExecIpcInformExecutorRequest,
+) -> Result<(), anyhow::Error> {
+    use prost::Message;
+    use tokio::io::AsyncWriteExt;
+    let mut ipc = tokio::fs::File::from_std(std::fs::File::from(ipc_fd));
+    let payload = zeroize::Zeroizing::new(message.encode_to_vec());
+    ipc.write_all(payload.as_slice())
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to inform executor; {}", e))?;
+    ipc.flush()
+        .await
+        .map_err(|e| anyhow::anyhow!("Failed to inform executor (flush); {}", e))?;
+    drop(ipc);
+    tracing::debug!("Informed executor");
+    Ok(())
+}
+
+#[tracing::instrument(name = "run_sidecar", skip_all)]
+async fn do_sidecar_inner(mut args: ExecArgs) -> Result<SidecarHandler, anyhow::Error> {
     let mut agent = crate::cmd::agent::connect_or_start().await?;
 
     if args.role == "auto" {
@@ -66,12 +169,15 @@ async fn run_inner(mut args: ExecArgs) -> Result<(), anyhow::Error> {
         }
     }
 
-    let _auto_refresh_shutdown_tx =
-        auto_refresh::start(agent.clone(), args.clone(), initial_expiry); // keep running
-    let _provider_shutdown_tx = provider::start(&mut agent, &args).await?; // keep provider running
+    let auto_refresh_shutdown_tx = auto_refresh::start(agent.clone(), args.clone(), initial_expiry); // keep running
+    let provider = provider::start(&mut agent, &args).await?; // keep provider running
 
-    execute(&args).await
+    Ok(SidecarHandler {
+        auto_refresh_shutdown_tx,
+        provider,
+    })
 }
+
 #[tracing::instrument(skip_all)]
 async fn resolve_auto(args: &mut ExecArgs) -> Result<(), anyhow::Error> {
     let cwd = std::env::current_dir()
@@ -124,6 +230,7 @@ async fn resolve_auto(args: &mut ExecArgs) -> Result<(), anyhow::Error> {
     Ok(())
 }
 
+#[tracing::instrument(skip_all)]
 async fn ask_trust(args: &ExecArgs, auto: &crate::auto::Auto) -> Result<(), anyhow::Error> {
     let product = env!("CARGO_PKG_NAME");
 
@@ -304,6 +411,7 @@ mod provider {
     use super::*;
 
     pub(super) struct ProviderHandle {
+        #[allow(dead_code)] // TODO: use ProviderHandle#shutdown
         pub(super) shutdown: tokio::sync::oneshot::Sender<()>,
         pub(super) environment: crate::proto::ExecEnvironment,
     }
@@ -590,96 +698,61 @@ mod auto_refresh {
     }
 }
 
-#[tracing::instrument(skip_all)]
-async fn execute(args: &ExecArgs) -> Result<(), anyhow::Error> {
-    use tokio_stream::StreamExt;
-    let arg0 = args
-        .command
-        .first()
-        .ok_or_else(|| anyhow::anyhow!("command cannot be empty"))?;
-    let mut child = tokio::process::Command::new(arg0)
-        .args(&args.command[1..])
-        .spawn()?;
-    let pid = child.id();
+mod executor {
+    use super::*;
 
-    start_ignoring_signals();
-    let forwarded_signals = execute_listen_for_forwarded_signals(&args.forward_signals);
-    let waitpid = child.wait();
+    #[tracing::instrument(name = "executor_run", skip_all)]
+    pub(super) fn run(
+        sidecar_pid: nix::unistd::Pid,
+        ipc_fd: std::os::fd::OwnedFd,
+        args: ExecArgs,
+    ) -> Result<(), anyhow::Error> {
+        use prost::Message;
+        use std::io::Read;
 
-    tokio::pin!(waitpid);
-    tokio::pin!(forwarded_signals);
-    loop {
-        tokio::select! {
-            maybe_status = &mut waitpid => {
-                let status = maybe_status.unwrap();
-                return match status.code() {
-                    Some(0) => Ok(()),
-                    Some(code) => {
-                        let returning_code = std::process::ExitCode::from(code as u8);
-                        Err(crate::Error::SilentlyExitWithCode(returning_code).into())
-                    }
-                    None => handle_exit_status_signaled(status),
-                }
+        tracing::trace!(sidecar_pid = ?sidecar_pid, "Waiting for information from the sidecar");
+        let info = {
+            let mut ipc = std::fs::File::from(ipc_fd);
+            let mut buf = zeroize::Zeroizing::new(vec![]);
+            ipc.read_to_end(&mut buf)
+                .map_err(|e| anyhow::anyhow!("Failed to read data from sidecar; {}", e))?;
+            crate::proto::ExecIpcInformExecutorRequest::decode(&mut std::io::Cursor::new(
+                buf.as_slice(),
+            ))
+            .map_err(|e| {
+                anyhow::anyhow!(
+                    "Failed to decode data from sidecar (it maybe unexpectedly crashed?); {}",
+                    e
+                )
+            })?
+        };
+        match info.into_std() {
+            Err(e) => {
+                tracing::error!(err = ?e, "Error in sidecar");
+                Err(crate::Error::FailureButSilentlyExit.into())
             }
-            signal =  forwarded_signals.next() => {
-                tracing::debug!(signal = ?signal, pid = ?pid, "Forwarding signal");
-                #[cfg(unix)]
-                if let Some(pid_u32) = pid {
-                    if let Err(e) = nix::sys::signal::kill(nix::unistd::Pid::from_raw(pid_u32 as i32), signal) {
-                        tracing::warn!(signal = ?signal, pid = ?pid, err = ?e, "Failed to forward signal; kill(2) returned error");
-                    }
-                }
-            }
+            // Sidecar is ready (provider is up and running); execvp(2) the given command
+            Ok(info) => execute(info, args),
         }
     }
-}
 
-#[cfg(unix)]
-fn execute_listen_for_forwarded_signals(
-    signal_names: &Vec<String>,
-) -> impl futures_core::stream::Stream<Item = nix::sys::signal::Signal> {
-    use std::str::FromStr;
-    use tokio_stream::StreamExt;
-
-    let streams = signal_names
-        .iter()
-        .filter_map(
-            |name| match nix::sys::signal::Signal::from_str(name.as_str()) {
-                Ok(sig) => Some(sig),
-                Err(e) => {
-                    tracing::warn!(err = ?e, signal_name = ?name, "Unknown signal to forward: {name}");
-                    None
-                }
-            },
-        )
-        .filter_map(|sig| {
-            match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::from_raw(
-                sig as std::os::raw::c_int,
-            )) {
-                Ok(l) => Some((sig, tokio_stream::wrappers::SignalStream::new(l))),
-                Err(e) => {
-                    tracing::warn!(err = ?e, signal = ?sig, "Failed to listen for forwarded signal");
-                    None
-                }
-            }
-        });
-    let mut map = tokio_stream::StreamMap::from_iter(streams);
-
-    async_stream::stream! {
-        while let Some((sig, _)) = map.next().await {
-            yield sig;
+    fn execute(
+        info: crate::proto::exec_ipc_inform_executor_request::Ready,
+        args: ExecArgs,
+    ) -> Result<(), anyhow::Error> {
+        use std::os::unix::process::CommandExt;
+        if let Some(env) = info.environment {
+            env.apply();
         }
+        let arg0 = args
+            .command
+            .first()
+            .ok_or_else(|| anyhow::anyhow!("command cannot be empty"))?;
+        let err = std::process::Command::new(arg0)
+            .args(&args.command[1..])
+            .exec();
+        anyhow::bail!("Couldn't exec the command line: {}", err);
     }
-}
-
-#[cfg(unix)]
-fn handle_exit_status_signaled(status: std::process::ExitStatus) -> Result<(), anyhow::Error> {
-    use std::os::unix::process::ExitStatusExt;
-    if let Some(sig) = status.signal() {
-        let code = std::process::ExitCode::from(128 + (sig as u8));
-        return Err(crate::Error::SilentlyExitWithCode(code).into());
-    }
-    Err(crate::Error::FailureButSilentlyExit.into())
 }
 
 #[cfg(unix)]

--- a/src/error.rs
+++ b/src/error.rs
@@ -48,6 +48,9 @@ pub enum Error {
     #[error(transparent)]
     RemoteError(#[from] crate::client::Error),
 
+    #[error("{0}")]
+    SidecarError(String),
+
     /// Failure, but we don't want to emit error to stderr/out anymore. Used in cmd
     #[error("")]
     FailureButSilentlyExit,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,7 @@ pub use error::{Error, Result};
 
 pub mod ext_axum;
 pub mod ext_oauth2;
+pub mod ppid;
 pub mod singleflight;
 pub mod terminal;
 

--- a/src/ppid.rs
+++ b/src/ppid.rs
@@ -1,0 +1,102 @@
+#[cfg(unix)]
+pub async fn wait_for_parent_process_die(parent: nix::unistd::Pid) -> Result<(), anyhow::Error> {
+    use tokio_stream::StreamExt;
+
+    let (signal, has_signal) = {
+        let can_signal = match subscribe_parent_process_die_as_signal() {
+            Ok(b) => b,
+            Err(e) => {
+                tracing::warn!(err = ?e, "Failed to subscribe parent process exit as signal");
+                false
+            }
+        };
+        if can_signal {
+            match tokio::signal::unix::signal(PDEATHSIG_TOKIO) {
+                Ok(s) => (future_maybe_signal(Some(s)), true),
+                Err(e) => {
+                    tracing::warn!(err = ?e, "Failed to monitor for SIGUSR1 (to detect executor process exit)");
+                    (future_maybe_signal(None), false)
+                }
+            }
+        } else {
+            (future_maybe_signal(None), false)
+        }
+    };
+
+    let ppid_monitor = monitor_ppid(parent, has_signal);
+
+    tokio::pin!(signal);
+    tokio::pin!(ppid_monitor);
+    loop {
+        tokio::select! {
+            sig = signal.next(), if has_signal  => {
+                if sig.is_some() {
+                    tracing::debug!("parent die notified via signal");
+                    break;
+                }
+            },
+            _ = &mut ppid_monitor => {
+                break;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn future_maybe_signal(
+    maybe: Option<tokio::signal::unix::Signal>,
+) -> impl futures_core::stream::Stream<Item = Option<()>> {
+    use tokio_stream::StreamExt;
+    async_stream::stream! {
+        match maybe {
+            Some(sig) => {
+                let mut s = tokio_stream::wrappers::SignalStream::new(sig);
+                while let Some(s) = s.next().await {
+                    yield Some(s);
+                }
+            }
+            None =>  yield None,
+        }
+    }
+}
+
+#[cfg(unix)]
+async fn monitor_ppid(parent: nix::unistd::Pid, is_efficient: bool) -> Result<(), anyhow::Error> {
+    // getppid(2) returns != parent when parent dies. This is still, always required to avoid
+    // race condition issue with other efficient ways; A parent could die before setting such
+    // methods up.
+    let interval = tokio::time::Duration::from_secs(if is_efficient { 20 } else { 3 });
+    loop {
+        if parent != nix::unistd::getppid() {
+            break;
+        }
+        tokio::time::sleep(interval).await;
+    }
+    tracing::debug!("monitor_ppid detected parent die");
+    Ok(())
+}
+
+cfg_if::cfg_if! {
+    if #[cfg(target_os = "linux")] {
+        fn subscribe_parent_process_die_as_signal() -> Result<bool, anyhow::Error> {
+            nix::sys::prctl::set_pdeathsig(PDEATHSIG)?;
+            Ok(true)
+        }
+    } else if #[cfg(any(target_os = "freebsd", target_os = "dragonfly"))] {
+        fn subscribe_parent_process_die_as_signal() -> Result<bool, anyhow::Error> {
+            // FIXME: https://github.com/nix-rust/nix/pull/2164
+            rustix::process::procctl::set_parent_process_death_signal(Some(PDEATHSIG as i32))
+                .map_err(|e| anyhow::error!("Failed to set_parent_process_death_signal (PROC_PDEATHSIG_CTL); {}", e))?;
+            todo!()
+        }
+    } else {
+        #[inline]
+        fn subscribe_parent_process_die_as_signal() -> Result<bool, anyhow::Error> {
+            Ok(false)
+        }
+    }
+}
+
+static PDEATHSIG: nix::sys::signal::Signal = nix::sys::signal::Signal::SIGUSR1;
+static PDEATHSIG_TOKIO: tokio::signal::unix::SignalKind =
+    tokio::signal::unix::SignalKind::from_raw(PDEATHSIG as i32);

--- a/src/proto.rs
+++ b/src/proto.rs
@@ -25,3 +25,42 @@ impl Session {
         }
     }
 }
+
+impl ExecEnvironment {
+    pub(crate) fn apply(&self) {
+        for name in self.remove_vars.iter() {
+            std::env::remove_var(name);
+        }
+        for ExecEnvVar { name, value } in self.set_vars.iter() {
+            std::env::set_var(name, value);
+        }
+    }
+}
+
+#[derive(zeroize::ZeroizeOnDrop)]
+pub(crate) enum ExecEnvironmentAction {
+    Set(#[zeroize(skip)] &'static str, String),
+    Remove(#[zeroize(skip)] &'static str),
+}
+
+impl FromIterator<ExecEnvironmentAction> for ExecEnvironment {
+    fn from_iter<I: IntoIterator<Item = ExecEnvironmentAction>>(iter: I) -> Self {
+        let mut set_vars = vec![];
+        let mut remove_vars = vec![];
+
+        for action in iter {
+            match &action {
+                ExecEnvironmentAction::Set(name, value) => set_vars.push(ExecEnvVar {
+                    name: name.to_string(),
+                    value: value.clone(),
+                }),
+                ExecEnvironmentAction::Remove(name) => remove_vars.push(name.to_string()),
+            }
+        }
+
+        ExecEnvironment {
+            set_vars,
+            remove_vars,
+        }
+    }
+}


### PR DESCRIPTION
This change makes mairu-exec to spawn a credential provider in a child process, instead of: run a target command in a child process which were formerly done. We now call a child process running a credential provider 'sidecar'. A sidecar will be launched via fork(2).

And a parent process; an original mairu-exec process ran by user is now responsible to execvp(2) a specified target command. We now call the parent process an 'executor'.

This strategy lets Mairu transparent from other processes, in terms of handling signal and returning exit status; including signals (WTERMSIG). OTOH, other processes that execute mairu-exec doesn't have to care about a weird intermediate process (mairu-exec) anymore. Previously an user has to take care of, for instance specifying --forward-signals.

Now mairu-exec spawns a sidecar by fork(2) with pipe(2) and the mairu-exec itself (parent process) calls an executor function. The spawned sidecar prepares a credential provider as like as we've done before, and informs the executor when it become ready. The executor waits for an information from the sidecar, then execvp(2) a specified target command line with applying the given information, for instance, AWS_* environment variables.

The sidecar monitors the parent process (formerly an executor) while it keeps provider running, and it quits when the parent is gone.

There is an optimization to notice a parent dismissal on Linux, FreeBSD, DragonFlyBSD but at this moment a successful build is only verified on Linux.

There is an optimization path to notice a parent dismissal on Linux, FreeBSD, DragonFlyBSD thru signal, but at this moment a successful build is only verified on Linux.

This design is inspired by ssh-agent(1); a ssh-agent will run in a child process of a given command of ssh-agent(1) and terminates when the command ends.