### PR TITLE
aws_sso: Dedicated client by grant_type

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ hyper = { version = "1.1.0", features = ["http1", "server"] }
 hyper-util = "0.1.10"
 indoc = "2.0.5"
 libc = "0.2.153"
-nix = { version = "0.29.0", features = ["resource", "process", "ptrace", "mman", "fs", "signal"] }
+nix = { version = "0.29.0", features = ["resource", "process", "ptrace", "mman", "fs", "signal", "hostname"] }
 oauth2 = "5.0.0-rc.1"
 once_cell = { version = "1.19.0", features = ["parking_lot"] }
 parking_lot = "0.12.1"

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -162,7 +162,7 @@ impl crate::proto::agent_server::Agent for Agent {
         };
 
         if server.aws_sso.is_some() {
-            server.ensure_aws_sso_oauth_client_registration(false)
+            server.ensure_aws_sso_oauth_client_registration(true, crate::config::OAuthGrantType::Code)
                 .await
                 .map_err(|e| {
                     tracing::error!(err = ?e, server_id = server.id(), "error while refreshing oauth client registration");
@@ -255,7 +255,7 @@ impl crate::proto::agent_server::Agent for Agent {
         };
 
         if server.aws_sso.is_some() {
-            server.ensure_aws_sso_oauth_client_registration(false)
+            server.ensure_aws_sso_oauth_client_registration(true, crate::config::OAuthGrantType::DeviceCode)
                 .await
                 .map_err(|e| {
                     tracing::error!(err = ?e, server_id = server.id(), "error while refreshing oauth client registration");
@@ -351,10 +351,16 @@ impl crate::proto::agent_server::Agent for Agent {
         //    ))
         //})?;
 
-        server.ensure_aws_sso_oauth_client_registration(true)
+        server.ensure_aws_sso_oauth_client_registration(true, crate::config::OAuthGrantType::Code)
             .await
             .map_err(|e| {
-                tracing::error!(err = ?e, server_id = server.id(), "error while refreshing oauth client registration");
+                tracing::error!(err = ?e, server_id = server.id(), "error while refreshing oauth client registration (Code)");
+                tonic::Status::internal(format!("error while refreshing oauth client registration: {e}"))
+            })?;
+        server.ensure_aws_sso_oauth_client_registration(true, crate::config::OAuthGrantType::DeviceCode)
+            .await
+            .map_err(|e| {
+                tracing::error!(err = ?e, server_id = server.id(), "error while refreshing oauth client registration (DeviceCode)");
                 tonic::Status::internal(format!("error while refreshing oauth client registration: {e}"))
             })?;
 

--- a/src/ext_awssso.rs
+++ b/src/ext_awssso.rs
@@ -20,9 +20,13 @@ pub async fn register_client(
     let ssooidc = sso_config_to_ssooidc(sso).await;
 
     let product = env!("CARGO_PKG_NAME");
+    let hostname = nix::unistd::gethostname()
+        .ok()
+        .and_then(|x| x.into_string().ok())
+        .unwrap_or_else(|| "?".to_string());
     let mut req = ssooidc
         .register_client()
-        .client_name(format!("{} ({})", product, server.id()))
+        .client_name(format!("{} ({}@{})", product, server.id(), hostname))
         .client_type("public")
         .grant_types("authorization_code")
         .grant_types("refresh_token")

--- a/src/ext_awssso.rs
+++ b/src/ext_awssso.rs
@@ -12,12 +12,19 @@ pub async fn sso_config_to_ssooidc(sso: &crate::config::ServerAwsSso) -> aws_sdk
 
 pub async fn register_client(
     server: &crate::config::Server,
+    purpose: crate::config::OAuthGrantType,
 ) -> crate::Result<crate::config::AwsSsoClientRegistrationCache> {
     let sso = server.aws_sso.as_ref().ok_or_else(|| {
         crate::Error::UserError(format!("Server '{}' is not an aws_sso server", server.id(),))
     })?;
 
     let ssooidc = sso_config_to_ssooidc(sso).await;
+
+    // XXX: We need to maintain separate client registrations per grant_type (`purpose`).
+    // A client must be registered with grant_types parameter to opt-in to authorization_code grant
+    // (in addition to device_code type, which was grant_type only supported in AWS SSO),
+    // but AWS SSO returns internal exception with HTTP 500 status code when a client registration
+    // has both grant_types("urn:ietf:params:oauth:grant-type:device_code") and grant_types("authorization_code").
 
     let product = env!("CARGO_PKG_NAME");
     let hostname = nix::unistd::gethostname()
@@ -28,11 +35,13 @@ pub async fn register_client(
         .register_client()
         .client_name(format!("{} ({}@{})", product, server.id(), hostname))
         .client_type("public")
-        .grant_types("authorization_code")
-        .grant_types("refresh_token")
-        .grant_types("urn:ietf:params:oauth:grant-type:device_code")
         .issuer_url(server.url.to_string())
         .redirect_uris("http://127.0.0.1/oauth/callback"); // [::1] is refused by AWS
+    if matches!(purpose, crate::config::OAuthGrantType::Code) {
+        req = req
+            .grant_types("authorization_code")
+            .grant_types("refresh_token");
+    }
     if !sso.scope.is_empty() {
         req = req.scopes(sso.scope.join(" "))
     }
@@ -158,10 +167,10 @@ impl aws_smithy_runtime_api::client::interceptors::Intercept for EndpointStealin
     fn read_before_serialization(
         &self,
         _context: &aws_smithy_runtime_api::client::interceptors::context::BeforeSerializationInterceptorContextRef<
-            '_,
-            aws_smithy_runtime_api::client::interceptors::context::Input,
-            aws_smithy_runtime_api::client::interceptors::context::Output,
-            aws_smithy_runtime_api::client::interceptors::context::Error,
+        '_,
+        aws_smithy_runtime_api::client::interceptors::context::Input,
+        aws_smithy_runtime_api::client::interceptors::context::Output,
+        aws_smithy_runtime_api::client::interceptors::context::Error,
         >,
         runtime_components: &aws_smithy_runtime_api::client::runtime_components::RuntimeComponents,
         cfg: &mut aws_smithy_types::config_bag::ConfigBag,

--- a/src/oauth_awssso_code.rs
+++ b/src/oauth_awssso_code.rs
@@ -23,16 +23,7 @@ impl AwsSsoCodeFlow {
         server: &crate::config::Server,
         redirect_url: &url::Url,
     ) -> crate::Result<Self> {
-        // TODO: try_aws_sso?
-        let aws_sso = server.aws_sso.as_ref().ok_or_else(|| {
-            crate::Error::ConfigError(format!("Server '{}' is not an aws_sso server", server.id()))
-        })?;
-        let oauth = server.oauth.as_ref().ok_or_else(|| {
-            crate::Error::ConfigError(format!(
-                "Server '{}' is missing an OAuth 2.0 client registration",
-                server.id()
-            ))
-        })?;
+        let (aws_sso, oauth) = server.try_oauth_awssso(crate::config::OAuthGrantType::Code)?;
         let mut authorize_url = crate::ext_awssso::ssooidc_authorize_url(aws_sso).await;
         let (pkce_challenge, pkce_verifier) = crate::ext_oauth2::generate_pkce_challenge();
         let csrf_token = oauth2::CsrfToken::new_random();

--- a/src/oauth_awssso_code.rs
+++ b/src/oauth_awssso_code.rs
@@ -61,18 +61,9 @@ impl AwsSsoCodeFlow {
         completion: crate::proto::CompleteOAuthCodeRequest,
     ) -> crate::Result<crate::token::ServerToken> {
         tracing::info!(flow = ?self, "Completing OAuth 2.0 Authorization Code flow (AWS SSO)");
-        let aws_sso = self.server.aws_sso.as_ref().ok_or_else(|| {
-            crate::Error::ConfigError(format!(
-                "Server '{}' is not an aws_sso server",
-                self.server.id(),
-            ))
-        })?;
-        let oauth = self.server.oauth.as_ref().ok_or_else(|| {
-            crate::Error::ConfigError(format!(
-                "Server '{}' is missing an OAuth 2.0 client registration",
-                self.server.id(),
-            ))
-        })?;
+        let (aws_sso, oauth) = self
+            .server
+            .try_oauth_awssso(crate::config::OAuthGrantType::Code)?;
 
         if self.csrf_token != completion.state {
             return Err(crate::Error::AuthError("csrf detected".to_owned()));

--- a/src/oauth_awssso_device_code.rs
+++ b/src/oauth_awssso_device_code.rs
@@ -25,15 +25,8 @@ impl From<&AwsSsoDeviceFlow> for crate::proto::InitiateOAuthDeviceCodeResponse {
 
 impl AwsSsoDeviceFlow {
     pub async fn initiate(server: &crate::config::Server) -> crate::Result<Self> {
-        let aws_sso = server.aws_sso.as_ref().ok_or_else(|| {
-            crate::Error::ConfigError(format!("Server '{}' is not an aws_sso server", server.id()))
-        })?;
-        let oauth = server.oauth.as_ref().ok_or_else(|| {
-            crate::Error::ConfigError(format!(
-                "Server '{}' is missing an OAuth 2.0 client registration",
-                server.id()
-            ))
-        })?;
+        let (aws_sso, oauth) =
+            server.try_oauth_awssso(crate::config::OAuthGrantType::DeviceCode)?;
         let handle = crate::utils::generate_flow_handle();
         tracing::info!(server = ?server, handle = ?handle, "Initiating AWS SSO Device Grant flow");
         let ssooidc = crate::ext_awssso::sso_config_to_ssooidc(aws_sso).await;

--- a/src/oauth_awssso_device_code.rs
+++ b/src/oauth_awssso_device_code.rs
@@ -75,18 +75,9 @@ impl AwsSsoDeviceFlow {
     }
 
     pub async fn complete(&self) -> crate::Result<crate::token::ServerToken> {
-        let aws_sso = self.server.aws_sso.as_ref().ok_or_else(|| {
-            crate::Error::ConfigError(format!(
-                "Server '{}' is not an aws_sso server",
-                self.server.id(),
-            ))
-        })?;
-        let oauth = self.server.oauth.as_ref().ok_or_else(|| {
-            crate::Error::ConfigError(format!(
-                "Server '{}' is missing an OAuth 2.0 client registration",
-                self.server.id(),
-            ))
-        })?;
+        let (aws_sso, oauth) = self
+            .server
+            .try_oauth_awssso(crate::config::OAuthGrantType::DeviceCode)?;
         tracing::debug!(server = ?self.server, handle = ?self.handle, "Checking AWS SSO Device Grant flow");
         let ssooidc = crate::ext_awssso::sso_config_to_ssooidc(aws_sso).await;
 

--- a/src/session_manager.rs
+++ b/src/session_manager.rs
@@ -142,7 +142,7 @@ impl Default for SessionManager {
 
 fn find_item_for_update(items: &[Session], token: &crate::token::ServerToken) -> Option<usize> {
     for (i, item) in items.iter().enumerate() {
-        if item.token.server.config_path == token.server.config_path
+        if item.token.server.config_path() == token.server.config_path()
             && item.token.server.id() == token.server.id()
             && item.token.server.url == token.server.url
         {


### PR DESCRIPTION
Maintain separate client registrations per grant_type for AWS SSO server.

A client must be registered with grant_types parameter to opt-in to authorization_code grant (in addition to device_code type, which was grant_type only supported in AWS SSO),

But, AWS SSO returns internal exception with HTTP 500 status code when a client registration has both grant_types("urn:ietf:params:oauth:grant-type:device_code") and grant_types("authorization_code").

We consider this is a bug in AWS SSO, but to align with AWS CLI behavior, maintain separate client registration per grant_type.