### PR TITLE
Support running as a public client against Microsoft Entra ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.4.0
 
 - Support OAuth 2.0 Authorization Code Grant without client secret; It's safe because we always use PKCE, and expects your authorization server to enforce PKCE.
+- `.oauth.code_grant` server configuration gains `use_localhost` flag, which forces redirect_uri to be `http://localhost:.../oauth2callback` instead of `http://127.0.0.1:.../oauth2callback`. This is required for some authorization servers, e.g. Microsoft + Mairu as a public client.
 
 ## 0.3.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.0
+
+- Support OAuth 2.0 Authorization Code Grant without client secret; It's safe because we always use PKCE, and expects your authorization server to enforce PKCE.
+
 ## 0.3.1
 
 - AWS SSO: fix failure on device code flow. This requires re-registration of OAuth 2.0 dynamic client (which is performed automatically).

--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ You may specify `--local-port` (or `.aws_sso.local_port`) to fix Authorization C
         "code_grant": {
             "authorization_endpoint": "...", // Omit if it is at ${url}/oauth/authorize
             "local_port": 16624, // Optional. Static port number to listen for oauth2 redirect_uri, otherwise ephemeral port is assigned and used.
+            "use_localhost": false, // Optional, default to false. Use http://localhost for redirect_uri. Has to be true for some issuers, i.e. Microsoft (public client).
         },
         "default_grant_type": "code_grant", // Optional
     }

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ You may specify `--local-port` (or `.aws_sso.local_port`) to fix Authorization C
 
     "oauth": {
         "client_id": "...",
-        "client_secret": "...",
+        "client_secret": "...", // Optional
 
         "token_endpoint": "...", // Optional if token_endpoint is at ${url}/oauth/token
         "scope": [], // Optional, default to ["profile"]

--- a/src/config.rs
+++ b/src/config.rs
@@ -471,6 +471,9 @@ impl ServerOAuth {
 pub struct ServerCodeGrant {
     pub authorization_endpoint: Option<url::Url>,
     pub local_port: Option<u16>,
+
+    #[serde(default)]
+    pub use_localhost: bool,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, Clone)]
@@ -536,6 +539,7 @@ impl AwsSsoClientRegistrationCache {
             code_grant: Some(ServerCodeGrant {
                 authorization_endpoint: None,
                 local_port: sso.local_port,
+                use_localhost: false,
             }),
             device_code_grant: Some(ServerDeviceCodeGrant {
                 device_authorization_endpoint: None,

--- a/src/oauth_code.rs
+++ b/src/oauth_code.rs
@@ -106,6 +106,7 @@ fn oauth2_client_from_server(
 pub async fn bind_tcp_for_callback(
     path: &str,
     port: Option<u16>,
+    use_localhost: bool,
 ) -> crate::Result<(tokio::net::TcpListener, url::Url)> {
     // FIXME: IPv6
     let bindaddr =
@@ -113,6 +114,9 @@ pub async fn bind_tcp_for_callback(
     let sock = tokio::net::TcpListener::bind(bindaddr).await?;
     let addr = sock.local_addr()?;
     let mut url = url::Url::parse("http://127.0.0.1/")?;
+    if use_localhost {
+        url.set_host(Some("localhost")).unwrap();
+    }
     url.set_path(path);
     url.set_port(Some(addr.port())).unwrap();
     tracing::debug!(url = %url, "Listening TCP for Callback");

--- a/src/oauth_code.rs
+++ b/src/oauth_code.rs
@@ -81,29 +81,25 @@ fn oauth2_client_from_server(
 > {
     let (oauth, code_grant) = server.try_oauth_code_grant()?;
 
-    let client = crate::ext_oauth2::SecrecyClient::new(oauth2::ClientId::new(oauth.client_id.clone()))
-        .set_client_secret(
-            oauth2::ClientSecret::new(
-                oauth
-                    .client_secret
+    let mut client =
+        crate::ext_oauth2::SecrecyClient::new(oauth2::ClientId::new(oauth.client_id.clone()))
+            .set_auth_uri(oauth2::AuthUrl::from_url(
+                code_grant
+                    .authorization_endpoint
                     .clone()
-                    .ok_or_else(|| crate::Error::ConfigError(format!("Server '{}' is missing OAuth 2.0 Client Secret; Required for Authorization Code Grant", server.id())))?
-            )
-        )
-        .set_auth_uri(oauth2::AuthUrl::from_url(
-            code_grant
-                .authorization_endpoint
-                .clone()
-                .map(Ok)
-                .unwrap_or_else(|| server.url.join("oauth/authorize"))?,
-        ))
-        .set_token_uri(oauth2::TokenUrl::from_url(
-                    oauth
-                        .token_endpoint
-                        .clone()
-                        .map(Ok)
-                        .unwrap_or_else(|| server.url.join("oauth/token"))?,
-        ));
+                    .map(Ok)
+                    .unwrap_or_else(|| server.url.join("oauth/authorize"))?,
+            ))
+            .set_token_uri(oauth2::TokenUrl::from_url(
+                oauth
+                    .token_endpoint
+                    .clone()
+                    .map(Ok)
+                    .unwrap_or_else(|| server.url.join("oauth/token"))?,
+            ));
+    if let Some(ref secret) = oauth.client_secret {
+        client = client.set_client_secret(oauth2::ClientSecret::new(secret.to_owned()));
+    }
     Ok(client)
 }
 


### PR DESCRIPTION
- Support OAuth 2.0 Authorization Code Grant without client secret; It's safe because we always use PKCE, and expects your authorization server to enforce PKCE.
- `.oauth.code_grant` server configuration gains `use_localhost` flag, which forces redirect_uri to be `http://localhost:.../oauth2callback` instead of `http://127.0.0.1:.../oauth2callback`.
