### PR TITLE
login: use redirect to access authorize_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Unreleased
+
+- login: during OAuth 2.0 Authorization Code flow, mairu now shows localhost URL that redirects to an actual authorize url. This allows to show shorter URLs, which ease opening URLs by avoiding line wrapping.
+
 ## 0.7.0
 
 - redirect_uri endpoint returns fancier HTML page during OAuth 2.0 Authorization Code flow.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,63 @@
+# Mairu Project Guide
+
+## Project Overview
+Mairu is a secure AWS credentials management tool written in Rust that allows seamless use of multiple AWS roles and accounts concurrently.
+
+## Development Commands
+- Build: `cargo build`
+- Test: `cargo test`
+- Type check: `cargo clippy` (preferred over `cargo check` for extensive linting)
+- Format: `cargo fmt`
+- Lint: `cargo clippy`
+
+## Key Architecture Notes
+- Agent-based architecture with gRPC communication
+- Credentials stored only in memory (never persisted to disk)
+- Uses Protocol Buffers for IPC (definitions in `proto/`)
+- Heavy use of async/await with Tokio runtime
+
+## Code Style
+- Follow standard Rust conventions
+- Use `thiserror` for error types
+- Use `zeroize` and `secrecy` for sensitive data handling
+- Prefer explicit error handling over panics
+- **Always run `cargo fmt` after writing or modifying code**
+- **Always run `cargo clippy` after writing or modifying code for extensive linting checks**
+- **Import (`use`) statements**: 
+  - Global `use` statements at the top of files are discouraged (except in `mod.rs` and `lib.rs`)
+  - Avoid `use` for structs and enums - prefer full paths (e.g., `std::collections::HashMap` instead of `use std::collections::HashMap`)
+  - `use` is allowed for frequently used modules within the same crate (e.g., `use crate::error::Error`)
+  - When importing traits, place the `use` statement in the most specific scope where they're needed
+  - Default: Don't use `use` unless explicitly requested by humans
+
+## Testing
+- Write unit tests in `#[cfg(test)]` modules
+- Run `cargo test` before committing changes
+- Tests require `protobuf-compiler` installed on the system
+
+## Security Considerations
+- AWS credentials are stored only in memory, never persisted to disk
+- Use `zeroize` for secure cleanup of sensitive data
+- OAuth 2.0 with PKCE is required for authorization code grant
+- Report security issues to security@sorah.jp and security@cookpad.com (not GitHub Issues)
+
+## Feature Flags
+- `default`: Uses native TLS implementation
+- `rustls`: Uses Rust TLS implementation (used for Debian packages)
+- Choose features with `cargo build --features rustls --no-default-features`
+
+## Release Process
+- Version is in `Cargo.toml`
+- Create tags as `v{VERSION}` (e.g., `v0.7.0`)
+- CI automatically builds releases for multiple architectures
+
+## Important Files
+- Server configs: `~/.config/mairu/servers.d/*.json`
+- Agent socket: `$XDG_RUNTIME_DIR/mairu-agent.sock`
+- Auto role config: `.mairu.json` in project directories
+- HTTP API spec: `HTTP_API_SPEC.md`
+
+## CI/CD
+- GitHub Actions runs tests on push/PR
+- Tests multiple targets: Linux (x86_64/aarch64, glibc/musl), macOS (aarch64)
+- Release workflow builds binaries and Debian packages

--- a/src/cmd/login.rs
+++ b/src/cmd/login.rs
@@ -94,20 +94,22 @@ pub async fn do_oauth_code(
     let product = env!("CARGO_PKG_NAME");
     let server_id = server.id();
     let server_url = &server.url;
-    let authorize_url = &session.authorize_url;
+
+    let (auth_route, short_authorize_url) =
+        crate::oauth_code::generate_short_authorize_url(&listener, use_localhost)?;
 
     crate::terminal::send(&indoc::formatdoc! {"
         :: {product} :: Login to {server_id} ({server_url}) ::::::::
         :: {product} ::
         :: {product} ::
         :: {product} :: Open the following URL to continue
-        :: {product} :: {authorize_url}
+        :: {product} :: >   {short_authorize_url}
         :: {product} ::
         :: {product} ::
     "})
     .await;
 
-    crate::oauth_code::listen_for_callback(listener, session, agent).await?;
+    crate::oauth_code::listen_for_callback(listener, session, agent, auth_route).await?;
     tracing::info!("Logged in");
     Ok(())
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -3,5 +3,5 @@ pub(crate) fn generate_flow_handle() -> String {
     use rand::RngCore;
     let mut buf = [0u8; 16];
     rand::rng().fill_bytes(&mut buf);
-    base64::engine::general_purpose::URL_SAFE.encode(buf)
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(buf)
 }


### PR DESCRIPTION
login: during OAuth 2.0 Authorization Code flow, mairu now shows localhost URL that redirects to an actual authorize url. This allows to show shorter URLs, which ease opening URLs by avoiding line wrapping.